### PR TITLE
AIR-5316 fix too greedy middleware pattern

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -4,7 +4,7 @@
 module HealthCheck
 
   class Engine < Rails::Engine
-    cattr_accessor :routes_explicitly_defined 
+    cattr_accessor :routes_explicitly_defined
   end
 
   # Text output upon success
@@ -34,7 +34,7 @@ module HealthCheck
 
   # health check uri path for middleware check
   mattr_accessor :uri
-  self.uri = 'health_check'
+  self.uri = '/health_check'
 
   # Basic Authentication
   mattr_accessor :basic_auth_username, :basic_auth_password

--- a/lib/health_check/middleware_health_check.rb
+++ b/lib/health_check/middleware_health_check.rb
@@ -7,7 +7,8 @@ module HealthCheck
 
     def call(env)
       uri = env['PATH_INFO']
-      if uri[/([^\.]*)/,1] == HealthCheck.uri
+      uriWithoutSuffix = uri[/([^\.]*)/,1]
+      if uriWithoutSuffix == HealthCheck.uri
         response_type = uri[/\.(json|xml)/,1] || 'plain'
         response_method = 'response_' + response_type
         checks = env['QUERY_STRING'][/checks=([a-z0-9\-_]*)/,1] || 'standard'

--- a/lib/health_check/middleware_health_check.rb
+++ b/lib/health_check/middleware_health_check.rb
@@ -1,14 +1,16 @@
 module HealthCheck
   class MiddlewareHealthcheck
 
+    URI_SUFFIX_REGEX = /\..*$/
+
     def initialize(app)
       @app = app
     end
 
     def call(env)
       uri = env['PATH_INFO']
-      uriWithoutSuffix = uri[/([^\.]*)/,1]
-      if uriWithoutSuffix == HealthCheck.uri
+      uri_without_suffix = uri.gsub URI_SUFFIX_REGEX, ''
+      if uri_without_suffix == HealthCheck.uri
         response_type = uri[/\.(json|xml)/,1] || 'plain'
         response_method = 'response_' + response_type
         checks = env['QUERY_STRING'][/checks=([a-z0-9\-_]*)/,1] || 'standard'

--- a/lib/health_check/middleware_health_check.rb
+++ b/lib/health_check/middleware_health_check.rb
@@ -7,7 +7,7 @@ module HealthCheck
 
     def call(env)
       uri = env['PATH_INFO']
-      if uri.include? HealthCheck.uri
+      if uri[/([^\.]*)/,1] == HealthCheck.uri
         response_type = uri[/\.(json|xml)/,1] || 'plain'
         response_method = 'response_' + response_type
         checks = env['QUERY_STRING'][/checks=([a-z0-9\-_]*)/,1] || 'standard'


### PR DESCRIPTION
Changed behaviour of health check middleware so now it compares exact URI's (removing .json|.xml from URI if exists). Previous version was too greedy and checked if config.uri exists in whole incoming URI, which could lead to taking by mistake any endpoint with this config.uri keyword inside as health check endpoint.
