### PR TITLE
Speed up the S3 read permission check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 = Change Log =
-
+* 2.4.1
+ * Speed up the S3 read permission check by decreasing the max_keys limit from 1'000 to 1.
 * 2.4.0
  * Added tests for middleware
  * Changed contributed middleware code to conform to existing url scheme
@@ -44,6 +45,6 @@
 	- reduced tests to the versions of ruby recomended for the different versions of rails
 * 1.1.2 - Change to bundler support for building gems, as jeweler gem was broken by v2.0.0 of rubygems
 * 1.1.0 - Include cache check (Thanks to https://github.com/mgomes1 ) and some changes to test setup to workaround and diagnose test failures under rvm
-* 1.0.2 - Included travis config and gemfiles used in travis tests in gem and changes to test setup so that gem test 
+* 1.0.2 - Included travis config and gemfiles used in travis tests in gem and changes to test setup so that gem test
 * 1.x - Includes Rails 3.x suppprt as an Engine
 * 0.x - Rails 2.3

--- a/lib/health_check/s3_health_check.rb
+++ b/lib/health_check/s3_health_check.rb
@@ -14,10 +14,10 @@ module HealthCheck
           end
           permissions.each do |permision|
             begin
-            send(permision, bucket_name)
-          rescue Exception => e
-            raise "bucket:#{bucket_name}, permission:#{permision} - #{e.message}"
-          end
+              send(permision, bucket_name)
+            rescue Exception => e
+              raise "bucket:#{bucket_name}, permission:#{permision} - #{e.message}"
+            end
           end
         end
         ''
@@ -47,7 +47,7 @@ module HealthCheck
       end
 
       def R(bucket)
-        aws_s3_client.list_objects(bucket: bucket)
+        aws_s3_client.list_objects(bucket: bucket, max_keys: 1)
       end
 
       def W(bucket)

--- a/lib/health_check/version.rb
+++ b/lib/health_check/version.rb
@@ -1,3 +1,3 @@
 module HealthCheck
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
The check is listing the bucket with default limit equal to 1'000.
It's significantly faster to list a single item, this PR does just that.

Cockpit STG:
```
irb(main):015:0> puts Benchmark.bm { |x| x.report { cli.list_objects(bucket: 'airhelp-webapp-staging', max_keys: 1) } }
       user     system      total        real
   0.004677   0.000000   0.004677 (  0.079930)
  0.004677   0.000000   0.004677 (  0.079930)
=> nil
irb(main):016:0> puts Benchmark.bm { |x| x.report { cli.list_objects(bucket: 'airhelp-webapp-staging') } }
       user     system      total        real
   0.091135   0.000000   0.091135 (  0.707922)
  0.091135   0.000000   0.091135 (  0.707922)
=> nil
```